### PR TITLE
Change version of navigation 2 to branch pilot-urjc

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -10,7 +10,7 @@ repositories:
   navigation2:
     type: git
     url: https://github.com/MROS-RobMoSys-ITP/navigation2.git
-    version: nav2_bt_modes_navigator
+    version: pilot-urjc
   ros2_planning_system:
     type: git
     url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
This PR is for changing the repo version of MROS navigation2 to pilot-urjc



Note: This PR should come from my fork, but I made a mistake and I push to this repo

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>