### PR TITLE
Remove BT dependencies

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,8 +1,4 @@
 repositories:
-  BehaviorTree.CPP:
-    type: git
-    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: master
   BICA:
     type: git
     url: https://github.com/IntelligentRoboticsLabs/BICA.git

--- a/pilot_behavior/CMakeLists.txt
+++ b/pilot_behavior/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Hi all,

We are removing references to C++17 in order to use official Behavior Tree version

Best



Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>