### PR TITLE
Fix errors founded in the re-launch of the pilot in foxy

### DIFF
--- a/metacontroller_pilot/metacontroller_pilot/metacontroller_sim.py
+++ b/metacontroller_pilot/metacontroller_pilot/metacontroller_sim.py
@@ -56,7 +56,6 @@ class Metacontroller(Node):
         while not cli.wait_for_service(timeout_sec=1.0):
             print('service not available, waiting again...')
         req = ChangeMode.Request()
-        req.node_name = node_name
         req.mode_name = mode_name
 
         future = cli.call_async(req)
@@ -80,48 +79,44 @@ def main(args=None):
     print (" 6) Network reset")
     print (" 7) Robot located")
     print (" 8) Obstructed solved")
+    print (" 9) Laser Error")
     print ("------------------------------")
 
     option = input()
 
     if option == "1":
         print ("Battery low.") 
-        node_name = 'pilot'
         mode_name = 'LOW_BATTERY'
     elif option == "2":
         print ("Internet lost. (Dialog down)") 
-        node_name = 'pilot'
         mode_name = 'DIALOG'  # doesn't exist  
     elif option == "3":
         print ("Robot lost.") 
-        node_name = 'pilot'
         mode_name = 'LOST'
     elif option == "4":
         print ("Obstacle.") 
-        node_name = 'pilot'
         mode_name = 'OBSTRUCTED'
     elif option == "5":
         print ("Charge completed.")
-        node_name = 'pilot'
         mode_name = 'NORMAL'
     elif option == "6":
         print ("Internet reset.")
-        node_name = 'pilot'
         mode_name = 'NORMAL'
     elif option == "7":
         print ("Robot located.")
-        node_name = 'pilot'
         mode_name = 'NORMAL'
     elif option == "8":
         print ("Obstacle deleted")
-        node_name = 'pilot'
         mode_name = 'NORMAL'
+    elif option == "9":
+        print ("Laser Error")
+        mode_name = 'LASER_ERROR'
     else:
         print("Invalid option.")
         sys.exit()
 
     rclpy.init(args=args)
-
+    node_name = "pilot"
     node = Metacontroller(node_name, mode_name)
 
     try:

--- a/pilot_behavior/src/behavior_tree_nodes/GetOrder.cpp
+++ b/pilot_behavior/src/behavior_tree_nodes/GetOrder.cpp
@@ -26,9 +26,9 @@ GetOrder::GetOrder(
 : BT::ActionNodeBase(xml_tag_name, conf)
 {
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-  graph_ = std::make_shared<ros2_knowledge_graph::GraphNode>(xml_tag_name + node_->get_name());
-
-  graph_->start();
+  //graph_ = std::make_shared<ros2_knowledge_graph::GraphNode>(xml_tag_name + node_->get_name());
+  //graph_->start();
+  graph_ = config().blackboard->get<std::shared_ptr<ros2_knowledge_graph::GraphNode>>("pilot_graph");
 }
 
 BT::NodeStatus

--- a/pilot_behavior/src/behavior_tree_nodes/InteractWithBarman.cpp
+++ b/pilot_behavior/src/behavior_tree_nodes/InteractWithBarman.cpp
@@ -26,9 +26,9 @@ InteractWithBarman::InteractWithBarman(
 : BT::ActionNodeBase(xml_tag_name, conf)
 {
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-  graph_ = std::make_shared<ros2_knowledge_graph::GraphNode>(xml_tag_name + node_->get_name());
-
-  graph_->start();
+  //graph_ = std::make_shared<ros2_knowledge_graph::GraphNode>(xml_tag_name + node_->get_name());
+  //graph_->start();
+  graph_ = config().blackboard->get<std::shared_ptr<ros2_knowledge_graph::GraphNode>>("pilot_graph");
 }
 
 BT::NodeStatus
@@ -36,6 +36,12 @@ InteractWithBarman::tick()
 {
   // TODO(fmrico): Decir la comanda al barman
   std::string text_to_say = "The table_1 wants: ";
+  
+  if (graph_->get_num_nodes() == 0)
+  {
+    RCLCPP_WARN(node_->get_logger(), "0 nodes received");
+    return BT::NodeStatus::RUNNING;
+  }
 
   RCLCPP_INFO(
     node_->get_logger(), "Nodes table_1 [%d]", graph_->get_node_names_by_id(

--- a/pilot_behavior/src/behavior_tree_nodes/NavigateToBarman.cpp
+++ b/pilot_behavior/src/behavior_tree_nodes/NavigateToBarman.cpp
@@ -33,8 +33,8 @@ NavigateToBarman::on_tick()
 {
   geometry_msgs::msg::PoseStamped goal;
 
-  goal.pose.position.x = 0.636;
-  goal.pose.position.y = 0.545;
+  goal.pose.position.x = -0.5;
+  goal.pose.position.y = -0.5;
   goal.header.frame_id = "map";
 
   goal_.pose = goal;

--- a/pilot_behavior/src/pilot_behavior.cpp
+++ b/pilot_behavior/src/pilot_behavior.cpp
@@ -29,6 +29,7 @@
 #include "behaviortree_cpp_v3/blackboard.h"
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ros2_knowledge_graph/GraphNode.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -50,7 +51,10 @@ int main(int argc, char ** argv)
 
   auto blackboard = BT::Blackboard::create();
   auto node = rclcpp::Node::make_shared("pilot_node");
+  auto graph = std::make_shared<ros2_knowledge_graph::GraphNode>("pilot_graph");
+  graph->start();
   blackboard->set("node", node);
+  blackboard->set("pilot_graph", graph);
 
   BT::Tree tree = factory.createTreeFromFile(xml_file, blackboard);
 


### PR DESCRIPTION
This PR fixes some issues founded during my re-launch of the Pilot URJC in foxy:
- Removes node_name field in the ChangeMode.Request srv.
- Fixes an issue with the ros2_knowledge_graph whereby an instance of the graph does not take the changes of another instance. I had to use the blackboard of the BTs to share an instance of the graphs between the different nodes.