### PR TITLE
Laser-failure scenario

### DIFF
--- a/laser_resender/CMakeLists.txt
+++ b/laser_resender/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(laser_resender)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE DEBUG)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+
+set(dependencies
+    rclcpp
+    rclcpp_lifecycle
+    lifecycle_msgs
+    std_msgs
+    sensor_msgs
+)
+
+add_executable(laser_resender_node src/laser_resender_node.cpp)
+ament_target_dependencies(laser_resender_node ${dependencies})
+
+install(TARGETS
+  laser_resender_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_export_dependencies(${dependencies})
+
+ament_package()

--- a/laser_resender/package.xml
+++ b/laser_resender/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>laser_resender</name>
+  <version>0.0.1</version>
+  
+  <description>Package with a managed laser resender to simulate a laser sensor error</description>
+
+  <maintainer email="jonatan.gines@urjc.es">jginesclavero</maintainer>
+ 
+  <license>Apache License, Version 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>lifecycle_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/laser_resender/src/laser_resender_node.cpp
+++ b/laser_resender/src/laser_resender_node.cpp
@@ -1,0 +1,104 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+// Execute: 
+//  ros2 lifecycle list /lifecycle_node_example
+//  ros2 lifecycle set /lifecycle_node_example configure
+
+using rcl_interfaces::msg::ParameterType;
+using std::placeholders::_1;
+using namespace std::placeholders;
+
+
+class LaserResender : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  LaserResender()
+  : rclcpp_lifecycle::LifecycleNode("laser_resender")
+  {
+    pub_ = create_publisher<sensor_msgs::msg::LaserScan>("/mros_scan", rclcpp::SensorDataQoS());
+    sub_ = create_subscription<sensor_msgs::msg::LaserScan>
+      ("/scan", rclcpp::SensorDataQoS(), std::bind(&LaserResender::scan_cb, this, _1));
+  }
+
+  using CallbackReturnT =
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  CallbackReturnT on_configure(const rclcpp_lifecycle::State & state)
+  {
+    RCLCPP_INFO(get_logger(), "[%s] Configuring from [%s] state...", get_name(), state.label().c_str());   
+    return CallbackReturnT::SUCCESS;
+  }
+
+  CallbackReturnT on_activate(const rclcpp_lifecycle::State & state) 
+  {
+    RCLCPP_INFO(get_logger(), "[%s] Activating from [%s] state...", get_name(), state.label().c_str());
+    pub_->on_activate();
+    return CallbackReturnT::SUCCESS;
+  }
+
+  CallbackReturnT on_deactivate(const rclcpp_lifecycle::State & state) 
+  {
+    RCLCPP_INFO(get_logger(), "[%s] Deactivating from [%s] state...", get_name(), state.label().c_str());
+    return CallbackReturnT::SUCCESS;
+  }
+
+  CallbackReturnT on_cleanup(const rclcpp_lifecycle::State & state) 
+  {
+    RCLCPP_INFO(get_logger(), "[%s] Cleanning Up from [%s] state...", get_name(), state.label().c_str());
+    return CallbackReturnT::SUCCESS;
+  }
+
+  CallbackReturnT on_shutdown(const rclcpp_lifecycle::State & state) 
+  {
+    RCLCPP_INFO(get_logger(), "[%s] Shutting Down from [%s] state...", get_name(), state.label().c_str());
+    return CallbackReturnT::SUCCESS;
+  }
+
+    CallbackReturnT on_error(const rclcpp_lifecycle::State & state) 
+  {
+    RCLCPP_INFO(get_logger(), "[%s] Shutting Down from [%s] state...", get_name(), state.label().c_str());
+    return CallbackReturnT::SUCCESS;
+  }
+
+  void scan_cb(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
+  {
+    if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+      pub_->publish(*laser_scan);
+    }
+  }
+
+private:
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::LaserScan>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr sub_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<LaserResender>();
+  rclcpp::spin(node->get_node_base_interface());
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/pilot_urjc_bringup/launch/nav2_navigation_launch.py
+++ b/pilot_urjc_bringup/launch/nav2_navigation_launch.py
@@ -47,7 +47,8 @@ def generate_launch_description():
     #              https://github.com/ros2/launch_ros/issues/56
     remappings = [('/tf', 'tf'),
                   ('/tf_static', 'tf_static'),
-                  ('cmd_vel', cmd_vel_topic)]
+                  ('cmd_vel', cmd_vel_topic),
+                  ('scan', 'mros_scan')]
 
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {
@@ -103,6 +104,11 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'cmd_vel_topic', default_value='cmd_vel',
             description='Command velocity topic'),
+        
+        Node(
+            package='laser_resender',
+            executable='laser_resender_node',
+            output='screen'),
 
         Node(
             package='nav2_controller',

--- a/pilot_urjc_bringup/launch/turtlebot3_sim/nav2_turtlebot3_launch.py
+++ b/pilot_urjc_bringup/launch/turtlebot3_sim/nav2_turtlebot3_launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
 
     declare_params_file_cmd = DeclareLaunchArgument(
         'params_file',
-        default_value=os.path.join(nav2_bringup_dir, 'params', 'nav2_params.yaml'),
+        default_value=os.path.join(pilot_dir, 'params', 'nav2_tb3_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
     declare_bt_xml_cmd = DeclareLaunchArgument(

--- a/pilot_urjc_bringup/launch/turtlebot3_sim/tb3_sim_launch.py
+++ b/pilot_urjc_bringup/launch/turtlebot3_sim/tb3_sim_launch.py
@@ -93,6 +93,28 @@ def generate_launch_description():
         remappings=remappings,
         arguments=[urdf])
 
+    pcl2laser_cmd = Node(
+        package='pointcloud_to_laserscan', 
+        executable='pointcloud_to_laserscan_managed',
+        name='pointcloud_to_laser',
+        remappings=[('cloud_in', '/intel_realsense_r200_depth/points'),
+                    ('scan', '/mros_scan')],
+        parameters=[{
+            'target_frame': 'base_scan',
+            'transform_tolerance': 0.01,
+            'min_height': 0.0,
+            'max_height': 1.0,
+            'angle_min': -1.5708,  # -M_PI/2
+            'angle_max': 1.5708,  # M_PI/2
+            'angle_increment': 0.0087,  # M_PI/360.0
+            'scan_time': 0.3333,
+            'range_min': 0.45,
+            'range_max': 4.0,
+            'use_inf': True,
+            'inf_epsilon': 1.0
+        }],
+    )
+
     ld = LaunchDescription()
 
     # Declare the launch options
@@ -107,5 +129,5 @@ def generate_launch_description():
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)
-    
+    ld.add_action(pcl2laser_cmd)
     return ld

--- a/pilot_urjc_bringup/params/nav2_tb3_params.yaml
+++ b/pilot_urjc_bringup/params/nav2_tb3_params.yaml
@@ -1,0 +1,308 @@
+amcl:
+  ros__parameters:
+    use_sim_time: True
+    alpha1: 0.2
+    alpha2: 0.2
+    alpha3: 0.2
+    alpha4: 0.2
+    alpha5: 0.2
+    base_frame_id: "base_footprint"
+    beam_skip_distance: 0.5
+    beam_skip_error_threshold: 0.9
+    beam_skip_threshold: 0.3
+    do_beamskip: false
+    global_frame_id: "map"
+    lambda_short: 0.1
+    laser_likelihood_max_dist: 2.0
+    laser_max_range: 100.0
+    laser_min_range: -1.0
+    laser_model_type: "likelihood_field"
+    max_beams: 60
+    max_particles: 2000
+    min_particles: 500
+    odom_frame_id: "odom"
+    pf_err: 0.05
+    pf_z: 0.99
+    recovery_alpha_fast: 0.0
+    recovery_alpha_slow: 0.0
+    resample_interval: 1
+    robot_model_type: "differential"
+    save_pose_rate: 0.5
+    sigma_hit: 0.2
+    tf_broadcast: true
+    transform_tolerance: 2.0
+    update_min_a: 0.2
+    update_min_d: 0.25
+    z_hit: 0.5
+    z_max: 0.05
+    z_rand: 0.5
+    z_short: 0.05
+    scan_topic: /mros_scan
+
+amcl_map_client:
+  ros__parameters:
+    use_sim_time: True
+
+amcl_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+bt_navigator:
+  ros__parameters:
+    use_sim_time: True
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /odom
+    default_bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
+    plugin_lib_names:
+    - nav2_compute_path_to_pose_action_bt_node
+    - nav2_follow_path_action_bt_node
+    - nav2_back_up_action_bt_node
+    - nav2_spin_action_bt_node
+    - nav2_wait_action_bt_node
+    - nav2_clear_costmap_service_bt_node
+    - nav2_is_stuck_condition_bt_node
+    - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
+    - nav2_initial_pose_received_condition_bt_node
+    - nav2_reinitialize_global_localization_service_bt_node
+    - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_truncate_path_action_bt_node
+    - nav2_goal_updater_node_bt_node
+    - nav2_recovery_node_bt_node
+    - nav2_pipeline_sequence_bt_node
+    - nav2_round_robin_node_bt_node
+    - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_distance_traveled_condition_bt_node
+
+bt_navigator_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+controller_server:
+  ros__parameters:
+    use_sim_time: True
+    controller_frequency: 20.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    progress_checker_plugin: "progress_checker"
+    goal_checker_plugin: "goal_checker"
+    controller_plugins: ["FollowPath"]
+
+    # Progress checker parameters
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+    # Goal checker parameters
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.3
+      yaw_goal_tolerance: 0.3
+      stateful: True
+    # DWB parameters
+    FollowPath:
+      plugin: "dwb_core::DWBLocalPlanner"
+      debug_trajectory_details: True
+      min_vel_x: 0.0
+      min_vel_y: 0.0
+      max_vel_x: 0.26
+      max_vel_y: 0.0
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.26
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+      acc_lim_x: 2.5
+      acc_lim_y: 0.0
+      acc_lim_theta: 3.2
+      decel_lim_x: -2.5
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 20
+      vy_samples: 5
+      vtheta_samples: 20
+      sim_time: 1.7
+      linear_granularity: 0.05
+      angular_granularity: 0.025
+      transform_tolerance: 0.2
+      xy_goal_tolerance: 0.3
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: True
+      stateful: True
+      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+      BaseObstacle.scale: 0.02
+      PathAlign.scale: 32.0
+      PathAlign.forward_point_distance: 0.1
+      GoalAlign.scale: 24.0
+      GoalAlign.forward_point_distance: 0.1
+      PathDist.scale: 32.0
+      GoalDist.scale: 24.0
+      RotateToGoal.scale: 32.0
+      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.lookahead_time: -1.0
+
+controller_server_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      global_frame: odom
+      robot_base_frame: base_link
+      use_sim_time: True
+      rolling_window: true
+      width: 3
+      height: 3
+      resolution: 0.05
+      robot_radius: 0.22
+      plugins: ["obstacle_layer", "inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: /mros_scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      voxel_layer:
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: True
+        publish_voxel_map: True
+        origin_z: 0.0
+        z_resolution: 0.05
+        z_voxels: 16
+        max_obstacle_height: 2.0
+        mark_threshold: 0
+        observation_sources: pointcloud
+        pointcloud:
+          topic: /intel_realsense_r200_depth/points
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "PointCloud2"
+      static_layer:
+        map_subscribe_transient_local: True
+      always_send_full_costmap: True
+  local_costmap_client:
+    ros__parameters:
+      use_sim_time: True
+  local_costmap_rclcpp_node:
+    ros__parameters:
+      use_sim_time: True
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_link
+      use_sim_time: True
+      robot_radius: 0.22
+      resolution: 0.05
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: /mros_scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      voxel_layer:
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: True
+        publish_voxel_map: True
+        origin_z: 0.0
+        z_resolution: 0.05
+        z_voxels: 16
+        max_obstacle_height: 2.0
+        mark_threshold: 0
+        observation_sources: pointcloud
+        pointcloud:
+          topic: /intel_realsense_r200_depth/points
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "PointCloud2"
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+      always_send_full_costmap: True
+  global_costmap_client:
+    ros__parameters:
+      use_sim_time: True
+  global_costmap_rclcpp_node:
+    ros__parameters:
+      use_sim_time: True
+
+map_server:
+  ros__parameters:
+    use_sim_time: True
+    yaml_filename: "turtlebot3_world.yaml"
+
+map_saver:
+  ros__parameters:
+    use_sim_time: True
+    save_map_timeout: 5000
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+    map_subscribe_transient_local: True
+
+planner_server:
+  ros__parameters:
+    expected_planner_frequency: 20.0
+    use_sim_time: True
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.5
+      use_astar: false
+      allow_unknown: true
+
+planner_server_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+recoveries_server:
+  ros__parameters:
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    recovery_plugins: ["spin", "backup", "wait"]
+    spin:
+      plugin: "nav2_recoveries/Spin"
+    backup:
+      plugin: "nav2_recoveries/BackUp"
+    wait:
+      plugin: "nav2_recoveries/Wait"
+    global_frame: odom
+    robot_base_frame: base_link
+    transform_timeout: 0.1
+    use_sim_time: true
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
+
+robot_state_publisher:
+  ros__parameters:
+    use_sim_time: True

--- a/pilot_urjc_bringup/params/pilot_modes.yaml
+++ b/pilot_urjc_bringup/params/pilot_modes.yaml
@@ -6,13 +6,19 @@ pilot:
     parts:
       controller_server
       bt_navigator
+      pointcloud_to_laser
     modes:
       __DEFAULT__:
         controller_server: active
         bt_navigator: active
+        pointcloud_to_laser: inactive
       MODERATE:
         controller_server: active.SLOW
         bt_navigator: active.ROUNDROBIN
+      LASER_ERROR:
+        pointcloud_to_laser: active
+        controller_server: active.LASER_ERROR
+        amcl: active.LASER_ERROR
       PERFORMANCE:
         controller_server: active.FAST
         bt_navigator: active.SIMPLE
@@ -27,6 +33,14 @@ pilot:
       NORMAL:
         controller_server: active.NORMAL
         bt_navigator: active.NORMAL
+
+pointcloud_to_laser:
+  ros__parameters:
+    type: node
+    modes:
+      __DEFAULT__:
+        ros__parameters:
+          pointcloud_to_laser_test: "0"
 
 bt_navigator:
   ros__parameters:
@@ -60,31 +74,42 @@ controller_server:
     modes:
       __DEFAULT__:
         ros__parameters:
-          max_vel_x: 0.26
-          max_vel_y: 0.0
-          max_vel_theta: 1.0
+          FollowPath.max_vel_x: 0.26
+          FollowPath.max_vel_theta: 1.0
+          FollowPath.transform_tolerance: 0.2
       SLOW:
         ros__parameters:
-          max_vel_x: 0.2
-          max_vel_y: 0.0
-          max_vel_theta: 0.6
+          FollowPath.max_vel_x: 0.2
+          FollowPath.max_vel_theta: 0.6
       FAST:
         ros__parameters:
-          max_vel_x: 0.35
-          max_vel_y: 0.0
-          max_vel_theta: 1.3
+          FollowPath.max_vel_x: 0.35
+          FollowPath.max_vel_theta: 1.3
       LOW_BATTERY: 
         ros__parameters:
-          max_vel_x: 0.2
-          max_vel_y: 0.0
-          max_vel_theta: 0.6
+          FollowPath.max_vel_x: 0.2
+          FollowPath.max_vel_theta: 0.6
+      LASER_ERROR: 
+        ros__parameters:
+          FollowPath.max_vel_x: 0.1
+          FollowPath.max_vel_theta: 0.4
+          FollowPath.transform_tolerance: 2.5
       LOST: 
         ros__parameters:
-          max_vel_x: 0.0
-          max_vel_y: 0.0
-          max_vel_theta: 0.0
+          FollowPath.max_vel_x: 0.0
+          FollowPath.max_vel_theta: 0.0
       NORMAL:
         ros__parameters:
-          max_vel_x: 0.26
-          max_vel_y: 0.0
-          max_vel_theta: 1.0
+          FollowPath.max_vel_x: 0.26
+          FollowPath.max_vel_theta: 1.0
+
+amcl:
+  ros__parameters:
+    type: node
+    modes:
+      __DEFAULT__:
+        ros__parameters:
+          transform_tolerance: 0.2
+      LASER_ERROR: 
+        ros__parameters:
+          transform_tolerance: 2.5


### PR DESCRIPTION
This PR adds some components to simulate a laser failure:
- Adds the laser_resender lifecycle node. In this way, we can manage the sent of laser msgs to simulate a laser failure.
- Adds the pointcloud_to_laser lifecycle node to the launcher. We use this node to convert the point cloud into laser to recover from the laser sensor failure.
- Updates in the system_modes param file.
