### PR TITLE
Add nav2_bt_modes_navigator pkg

### DIFF
--- a/nav2_bt_modes_navigator/CMakeLists.txt
+++ b/nav2_bt_modes_navigator/CMakeLists.txt
@@ -1,0 +1,82 @@
+cmake_minimum_required(VERSION 3.5)
+project(nav2_bt_modes_navigator)
+
+find_package(ament_cmake REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav2_behavior_tree REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(behaviortree_cpp_v3 REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(nav2_util REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+nav2_package()
+
+include_directories(
+  include
+)
+
+set(executable_name bt_modes_navigator)
+
+add_executable(${executable_name}
+  src/main.cpp
+)
+
+set(library_name ${executable_name}_core)
+
+add_library(${library_name} SHARED
+  src/bt_modes_navigator.cpp
+  src/ros_topic_logger.cpp
+)
+
+set(dependencies
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  std_msgs
+  geometry_msgs
+  nav2_behavior_tree
+  nav_msgs
+  nav2_msgs
+  behaviortree_cpp_v3
+  std_srvs
+  nav2_util
+  tf2_ros
+)
+
+ament_target_dependencies(${executable_name}
+  ${dependencies}
+)
+
+target_link_libraries(${executable_name} ${library_name})
+
+ament_target_dependencies(${library_name}
+  ${dependencies}
+)
+
+install(TARGETS ${executable_name} ${library_name}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+install(DIRECTORY behavior_trees DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(include)
+
+ament_package()

--- a/nav2_bt_modes_navigator/README.md
+++ b/nav2_bt_modes_navigator/README.md
@@ -1,0 +1,3 @@
+# BT Modes Navigator
+
+The BT Modes Navigator (Behavior Tree System Modes Navigator) module implements the [NavigateToPose task interface](../nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp) using [ROS2 System Modes](https://github.com/microROS/system_modes).

--- a/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning.xml
+++ b/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning.xml
@@ -1,0 +1,14 @@
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz.
+-->
+
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <PipelineSequence name="NavigateWithReplanning">
+      <RateController hz="1.0">
+        <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+      </RateController>
+      <FollowPath path="{path}"  controller_id="FollowPath"/>
+    </PipelineSequence>
+  </BehaviorTree>
+</root>

--- a/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_battery_warning.xml
+++ b/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_battery_warning.xml
@@ -1,0 +1,17 @@
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz.
+-->
+
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <PipelineSequence name="NavigateWithReplanning">
+      <RateController hz="0.2">
+        <BatteryWarning/>
+      </RateController>
+      <RateController hz="1.0">
+        <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+      </RateController>
+      <FollowPath path="{path}"  controller_id="FollowPath"/>
+    </PipelineSequence>
+  </BehaviorTree>
+</root>

--- a/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_obstacle_detected.xml
+++ b/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_obstacle_detected.xml
@@ -1,0 +1,24 @@
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz and it also has
+  recovery actions.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="2" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="4" name="ObstacleDetected">
+            <ObstacleDetected/>
+            <RoundRobin name="GlobalPlannerRecoveryActions">
+              <Wait wait_duration="2"/>
+              <Spin spin_dist="6.28"/>
+              <Spin spin_dist="0.1"/>
+              <Wait wait_duration="2"/>
+            </RoundRobin>
+          </RecoveryNode>
+        </RateController>
+      </PipelineSequence>
+        <Wait wait_duration="2"/>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -1,0 +1,31 @@
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz and it also has
+  recovery actions.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <SequenceStar name="RecoveryActions">
+          <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+          <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          <Spin spin_dist="1.57"/>
+          <Wait wait_duration="5"/>
+        </SequenceStar>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_round_robin_recovery.xml
+++ b/nav2_bt_modes_navigator/behavior_trees/navigate_w_replanning_and_round_robin_recovery.xml
@@ -1,0 +1,30 @@
+
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz and it also has
+  recovery actions.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="2" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="4" name="ComputePathToPose">
+            <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+            <RoundRobin name="GlobalPlannerRecoveryActions">
+              <ClearEntireCostmap service_name="global_costmap/clear_entirely_global_costmap"/>
+              <Wait wait_duration="2"/>
+            </RoundRobin>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="4" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <RoundRobin name="PlannerRecoveryActions">
+            <ClearEntireCostmap service_name="local_costmap/clear_entirely_local_costmap"/>
+            <Spin spin_dist="1.57"/>
+          </RoundRobin>
+        </RecoveryNode>
+      </PipelineSequence>
+        <Wait wait_duration="5"/>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/nav2_bt_modes_navigator/include/nav2_bt_modes_navigator/bt_modes_navigator.hpp
+++ b/nav2_bt_modes_navigator/include/nav2_bt_modes_navigator/bt_modes_navigator.hpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BT_MODES_NAVIGATOR__BT_MODES_NAVIGATOR_HPP_
+#define NAV2_BT_MODES_NAVIGATOR__BT_MODES_NAVIGATOR_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_behavior_tree/behavior_tree_engine.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_util/simple_action_server.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/create_timer_ros.h"
+
+namespace nav2_bt_modes_navigator
+{
+/**
+ * @class nav2_bt_navigator::BtNavigator
+ * @brief An action server that uses behavior tree for navigating a robot to its
+ * goal position.
+ */
+class BtNavigator : public nav2_util::LifecycleNode
+{
+public:
+  /**
+   * @brief A constructor for nav2_bt_navigator::BtNavigator class
+   */
+  BtNavigator();
+  /**
+   * @brief A destructor for nav2_bt_navigator::BtNavigator class
+   */
+  ~BtNavigator();
+
+protected:
+  /**
+   * @brief Configures member variables
+   *
+   * Initializes action server for "NavigationToPose"; subscription to
+   * "goal_sub"; and builds behavior tree from xml file.
+   * @param state Reference to LifeCycle node state
+   * @return SUCCESS or FAILURE
+   */
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  /**
+   * @brief Activates action server
+   * @param state Reference to LifeCycle node state
+   * @return SUCCESS or FAILURE
+   */
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  /**
+   * @brief Deactivates action server
+   * @param state Reference to LifeCycle node state
+   * @return SUCCESS or FAILURE
+   */
+  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  /**
+   * @brief Resets member variables
+   * @param state Reference to LifeCycle node state
+   * @return SUCCESS or FAILURE
+   */
+  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+  /**
+   * @brief Called when in shutdown state
+   * @param state Reference to LifeCycle node state
+   * @return SUCCESS or FAILURE
+   */
+  nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
+  /**
+   * @brief Called when in error state
+   * @param state Reference to LifeCycle node state
+   */
+  nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
+
+  using Action = nav2_msgs::action::NavigateToPose;
+
+  using ActionServer = nav2_util::SimpleActionServer<Action>;
+
+  // Our action server implements the NavigateToPose action
+  std::unique_ptr<ActionServer> action_server_;
+
+  /**
+   * @brief Action server callbacks
+   */
+  void navigateToPose();
+
+  /**
+   * @brief Goal pose initialization on the blackboard
+   */
+  void initializeGoalPose();
+
+  /**
+   * @brief A subscription and callback to handle the topic-based goal published
+   * from rviz
+   */
+  void onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose);
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_sub_;
+
+  /**
+   * @brief Replace current BT with another one
+   * @param bt_xml_filename The file containing the new BT
+   * @return true if the resulting BT correspond to the one in bt_xml_filename. false
+   * if something went wrong, and previous BT is mantained
+   */
+  bool loadBehaviorTree(const std::string & bt_id);
+
+  BT::Tree tree_;
+
+  // The blackboard shared by all of the nodes in the tree
+  BT::Blackboard::Ptr blackboard_;
+
+  // The XML fiñe that cointains the Behavior Tree to create
+  std::string current_bt_xml_filename_;
+  std::string default_bt_xml_filename_;
+
+  // The wrapper class for the BT functionality
+  std::unique_ptr<nav2_behavior_tree::BehaviorTreeEngine> bt_;
+
+  // Libraries to pull plugins (BT Nodes) from
+  std::vector<std::string> plugin_lib_names_;
+
+  // A client that we'll use to send a command message to our own task server
+  rclcpp_action::Client<Action>::SharedPtr self_client_;
+
+  // A regular, non-spinning ROS node that we can use for calls to the action client
+  rclcpp::Node::SharedPtr client_node_;
+
+  // Spinning transform that can be used by the BT nodes
+  std::shared_ptr<tf2_ros::Buffer> tf_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  // Metrics for feedback
+  rclcpp::Time start_time_;
+  std::string robot_frame_;
+  std::string global_frame_;
+  double transform_tolerance_;
+
+  // Subscription for parameter change
+  rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
+  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+  bool new_behavior_tree_;
+};
+
+}  // namespace nav2_bt_modes_navigator
+
+#endif  // NAV2_BT_MODES_NAVIGATOR__BT_MODES_NAVIGATOR_HPP_

--- a/nav2_bt_modes_navigator/include/nav2_bt_modes_navigator/ros_topic_logger.hpp
+++ b/nav2_bt_modes_navigator/include/nav2_bt_modes_navigator/ros_topic_logger.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BT_NAVIGATOR__ROS_TOPIC_LOGGER_HPP_
+#define NAV2_BT_NAVIGATOR__ROS_TOPIC_LOGGER_HPP_
+
+#include <vector>
+#include "behaviortree_cpp_v3/loggers/abstract_logger.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_msgs/msg/behavior_tree_log.hpp"
+#include "nav2_msgs/msg/behavior_tree_status_change.h"
+
+namespace nav2_bt_modes_navigator
+{
+
+class RosTopicLogger : public BT::StatusChangeLogger
+{
+public:
+  RosTopicLogger(const rclcpp::Node::SharedPtr & ros_node, const BT::Tree & tree);
+
+  void callback(
+    BT::Duration timestamp,
+    const BT::TreeNode & node,
+    BT::NodeStatus prev_status,
+    BT::NodeStatus status) override;
+
+  void flush() override;
+
+protected:
+  rclcpp::Node::SharedPtr ros_node_;
+  rclcpp::Publisher<nav2_msgs::msg::BehaviorTreeLog>::SharedPtr log_pub_;
+  std::vector<nav2_msgs::msg::BehaviorTreeStatusChange> event_log_;
+};
+
+}   // namespace nav2_bt_navigator
+
+#endif   // NAV2_BT_NAVIGATOR__ROS_TOPIC_LOGGER_HPP_

--- a/nav2_bt_modes_navigator/package.xml
+++ b/nav2_bt_modes_navigator/package.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nav2_bt_modes_navigator</name>
+  <version>0.3.0</version>
+  <description>TODO</description>
+  <maintainer email="fmrico@gmail.com">Francisco Martin</maintainer>
+  <license>Apache-2.0</license>
+
+  <depend>tf2_ros</depend>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_action</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
+  <build_depend>nav2_behavior_tree</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>nav2_msgs</build_depend>
+  <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>nav2_util</build_depend>
+
+  <exec_depend>behaviortree_cpp_v3</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_action</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
+  <exec_depend>nav2_behavior_tree</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>nav2_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>nav2_util</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>system_modes</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nav2_bt_modes_navigator/src/bt_modes_navigator.cpp
+++ b/nav2_bt_modes_navigator/src/bt_modes_navigator.cpp
@@ -1,0 +1,403 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_bt_modes_navigator/bt_modes_navigator.hpp"
+
+#include <fstream>
+#include <memory>
+#include <streambuf>
+#include <string>
+#include <utility>
+#include <vector>
+#include <set>
+
+#include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
+#include "nav2_behavior_tree/bt_conversions.hpp"
+#include "nav2_bt_modes_navigator/ros_topic_logger.hpp"
+
+namespace nav2_bt_modes_navigator
+{
+
+using std::placeholders::_1;
+
+BtNavigator::BtNavigator()
+: nav2_util::LifecycleNode("bt_navigator", "", false),
+  start_time_(0)
+{
+  RCLCPP_INFO(get_logger(), "Creating");
+
+  const std::vector<std::string> plugin_libs = {
+    "nav2_compute_path_to_pose_action_bt_node",
+    "nav2_follow_path_action_bt_node",
+    "nav2_back_up_action_bt_node",
+    "nav2_spin_action_bt_node",
+    "nav2_wait_action_bt_node",
+    "nav2_clear_costmap_service_bt_node",
+    "nav2_is_stuck_condition_bt_node",
+    "nav2_goal_reached_condition_bt_node",
+    "nav2_initial_pose_received_condition_bt_node",
+    "nav2_goal_updated_condition_bt_node",
+    "nav2_reinitialize_global_localization_service_bt_node",
+    "nav2_rate_controller_bt_node",
+    "nav2_distance_controller_bt_node",
+    "nav2_speed_controller_bt_node",
+    "nav2_truncate_path_action_bt_node",
+    "nav2_change_goal_node_bt_node",
+    "nav2_recovery_node_bt_node",
+    "nav2_pipeline_sequence_bt_node",
+    "nav2_round_robin_node_bt_node",
+    "nav2_transform_available_condition_bt_node",
+    "nav2_time_expired_condition_bt_node",
+    "nav2_distance_traveled_condition_bt_node"
+  };
+
+  // Declare this node's parameters
+  declare_parameter("default_bt_xml_filename");
+  declare_parameter("plugin_lib_names", plugin_libs);
+  declare_parameter("transform_tolerance", rclcpp::ParameterValue(0.1));
+  declare_parameter("global_frame", std::string("map"));
+  declare_parameter("robot_base_frame", std::string("base_link"));
+  declare_parameter("odom_topic", std::string("odom"));
+}
+
+BtNavigator::~BtNavigator()
+{
+  RCLCPP_INFO(get_logger(), "Destroying");
+}
+
+nav2_util::CallbackReturn
+BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Configuring");
+
+  // use suffix '_rclcpp_node' to keep parameter file consistency #1773
+  auto options = rclcpp::NodeOptions().arguments(
+    {"--ros-args",
+      "-r", std::string("__node:=") + get_name() + "_rclcpp_node",
+      "--"});
+  // Support for handling the topic-based goal pose from rviz
+  client_node_ = std::make_shared<rclcpp::Node>("_", options);
+
+  self_client_ = rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(
+    client_node_, "navigate_to_pose");
+
+  tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+    get_node_base_interface(), get_node_timers_interface());
+  tf_->setCreateTimerInterface(timer_interface);
+  tf_->setUsingDedicatedThread(true);
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, this, false);
+
+  goal_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+    "goal_pose",
+    rclcpp::SystemDefaultsQoS(),
+    std::bind(&BtNavigator::onGoalPoseReceived, this, std::placeholders::_1));
+
+  action_server_ = std::make_unique<ActionServer>(
+    get_node_base_interface(),
+    get_node_clock_interface(),
+    get_node_logging_interface(),
+    get_node_waitables_interface(),
+    "navigate_to_pose", std::bind(&BtNavigator::navigateToPose, this), false);
+
+  // Get the libraries to pull plugins from
+  plugin_lib_names_ = get_parameter("plugin_lib_names").as_string_array();
+  global_frame_ = get_parameter("global_frame").as_string();
+  robot_frame_ = get_parameter("robot_base_frame").as_string();
+  transform_tolerance_ = get_parameter("transform_tolerance").as_double();
+
+  // Create the class that registers our custom nodes and executes the BT
+  bt_ = std::make_unique<nav2_behavior_tree::BehaviorTreeEngine>(plugin_lib_names_);
+
+  // Create the blackboard that will be shared by all of the nodes in the tree
+  blackboard_ = BT::Blackboard::create();
+
+  // Put items on the blackboard
+  blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
+  blackboard_->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(10));  // NOLINT
+  blackboard_->set<bool>("path_updated", false);  // NOLINT
+  blackboard_->set<bool>("initial_pose_received", false);  // NOLINT
+  blackboard_->set<int>("number_recoveries", 0);  // NOLINT
+
+  // Get the BT filename to use from the node parameter
+  get_parameter("default_bt_xml_filename", default_bt_xml_filename_);
+
+  new_behavior_tree_ = false;
+
+  // Setup callback for changes to parameters.
+  parameters_client_ = std::make_shared<rclcpp::AsyncParametersClient>(
+    this->get_node_base_interface(),
+    this->get_node_topics_interface(),
+    this->get_node_graph_interface(),
+    this->get_node_services_interface());
+
+  parameter_event_sub_ = parameters_client_->on_parameter_event(
+    std::bind(&BtNavigator::on_parameter_event_callback, this, _1));
+
+  if (!loadBehaviorTree(default_bt_xml_filename_)) {
+    RCLCPP_ERROR(get_logger(), "Error loading XML file: %s", default_bt_xml_filename_.c_str());
+    return nav2_util::CallbackReturn::FAILURE;
+  }
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+bool
+BtNavigator::loadBehaviorTree(const std::string & bt_xml_filename)
+{
+  // Use previous BT if it is the existing one
+  if (current_bt_xml_filename_ == bt_xml_filename) {
+    return true;
+  }
+
+  // Read the input BT XML from the specified file into a string
+  std::ifstream xml_file(bt_xml_filename);
+
+  if (!xml_file.good()) {
+    RCLCPP_ERROR(get_logger(), "Couldn't open input XML file: %s", bt_xml_filename.c_str());
+    return false;
+  }
+
+  auto xml_string = std::string(
+    std::istreambuf_iterator<char>(xml_file),
+    std::istreambuf_iterator<char>());
+
+  RCLCPP_DEBUG(get_logger(), "Behavior Tree file: '%s'", bt_xml_filename.c_str());
+  RCLCPP_DEBUG(get_logger(), "Behavior Tree XML: %s", xml_string.c_str());
+
+  // Create the Behavior Tree from the XML input
+  tree_ = bt_->buildTreeFromText(xml_string, blackboard_);
+  current_bt_xml_filename_ = bt_xml_filename;
+
+  return true;
+}
+
+nav2_util::CallbackReturn
+BtNavigator::on_activate(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Activating");
+
+  action_server_->activate();
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn
+BtNavigator::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Deactivating");
+
+  action_server_->deactivate();
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn
+BtNavigator::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Cleaning up");
+
+  // TODO(orduno) Fix the race condition between the worker thread ticking the tree
+  //              and the main thread resetting the resources, see #1344
+  goal_sub_.reset();
+  client_node_.reset();
+  self_client_.reset();
+
+  // Reset the listener before the buffer
+  tf_listener_.reset();
+  tf_.reset();
+
+  action_server_.reset();
+  plugin_lib_names_.clear();
+  blackboard_.reset();
+  bt_->haltAllActions(tree_.rootNode());
+  bt_.reset();
+
+  RCLCPP_INFO(get_logger(), "Completed Cleaning up");
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn
+BtNavigator::on_error(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn
+BtNavigator::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Shutting down");
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+void
+BtNavigator::navigateToPose()
+{
+  initializeGoalPose();
+
+  auto is_canceling = [this]() {
+      if (action_server_ == nullptr) {
+        RCLCPP_DEBUG(get_logger(), "Action server unavailable. Canceling.");
+        return true;
+      }
+
+      if (!action_server_->is_server_active()) {
+        RCLCPP_DEBUG(get_logger(), "Action server is inactive. Canceling.");
+        return true;
+      }
+
+      return action_server_->is_cancel_requested();
+    };
+
+  auto bt_xml_filename = action_server_->get_current_goal()->behavior_tree;
+
+  // Empty id in request is default for backward compatibility
+  bt_xml_filename = bt_xml_filename == "" ? default_bt_xml_filename_ : bt_xml_filename;
+
+  if (!loadBehaviorTree(bt_xml_filename)) {
+    RCLCPP_ERROR(
+      get_logger(), "BT file not found: %s. Navigation canceled",
+      bt_xml_filename.c_str(), current_bt_xml_filename_.c_str());
+    action_server_->terminate_current();
+    return;
+  }
+
+  RosTopicLogger topic_logger(client_node_, tree_);
+  std::shared_ptr<Action::Feedback> feedback_msg = std::make_shared<Action::Feedback>();
+
+  auto on_loop = [&]() {
+      if (action_server_->is_preempt_requested()) {
+        RCLCPP_INFO(get_logger(), "Received goal preemption request");
+        action_server_->accept_pending_goal();
+        initializeGoalPose();
+      }
+      topic_logger.flush();
+
+      // action server feedback (pose, duration of task,
+      // number of recoveries, and distance remaining to goal)
+      nav2_util::getCurrentPose(
+        feedback_msg->current_pose, *tf_, global_frame_, robot_frame_, transform_tolerance_);
+
+      geometry_msgs::msg::PoseStamped goal_pose;
+      blackboard_->get("goal", goal_pose);
+
+      feedback_msg->distance_remaining = nav2_util::geometry_utils::euclidean_distance(
+        feedback_msg->current_pose.pose, goal_pose.pose);
+
+      int recovery_count = 0;
+      blackboard_->get<int>("number_recoveries", recovery_count);
+      feedback_msg->number_of_recoveries = recovery_count;
+      feedback_msg->navigation_time = now() - start_time_;
+      action_server_->publish_feedback(feedback_msg);
+    };
+
+  // Execute the BT that was previously created in the configure step
+  nav2_behavior_tree::BtStatus rc;
+  bool finished = false;
+  while(!finished) {
+    rc = bt_->run(&tree_, on_loop, is_canceling);
+
+    if (new_behavior_tree_) {
+      finished = false;
+      new_behavior_tree_ = false;
+
+      if (!loadBehaviorTree(current_bt_xml_filename_)) {
+       RCLCPP_ERROR(get_logger(), "Error restarting behavior tree");
+      }
+    } else {
+      finished = true;
+    }
+  }
+
+  // Make sure that the Bt is not in a running state from a previous execution
+  // note: if all the ControlNodes are implemented correctly, this is not needed.
+  bt_->haltAllActions(tree_.rootNode());
+
+  switch (rc) {
+    case nav2_behavior_tree::BtStatus::SUCCEEDED:
+      RCLCPP_INFO(get_logger(), "Navigation succeeded");
+      action_server_->succeeded_current();
+      break;
+
+    case nav2_behavior_tree::BtStatus::FAILED:
+      RCLCPP_ERROR(get_logger(), "Navigation failed");
+      action_server_->terminate_current();
+      break;
+
+    case nav2_behavior_tree::BtStatus::CANCELED:
+      RCLCPP_INFO(get_logger(), "Navigation canceled");
+      action_server_->terminate_all();
+      break;
+
+    default:
+      throw std::logic_error("Invalid status return from BT");
+  }
+}
+
+void
+BtNavigator::initializeGoalPose()
+{
+  auto goal = action_server_->get_current_goal();
+
+  RCLCPP_INFO(
+    get_logger(), "Begin navigating from current location to (%.2f, %.2f)",
+    goal->pose.pose.position.x, goal->pose.pose.position.y);
+
+  // Reset state for new action feedback
+  start_time_ = now();
+  blackboard_->set<int>("number_recoveries", 0);  // NOLINT
+
+  // Update the goal pose on the blackboard
+  blackboard_->set("goal", goal->pose);
+}
+
+void
+BtNavigator::onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose)
+{
+  nav2_msgs::action::NavigateToPose::Goal goal;
+  goal.pose = *pose;
+  self_client_->async_send_goal(goal);
+}
+
+void
+BtNavigator::on_parameter_event_callback(
+  const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
+{
+  using namespace rcl_interfaces::msg;
+
+  for (auto & changed_parameter : event->changed_parameters) {
+    const auto & type = changed_parameter.value.type;
+    const auto & name = changed_parameter.name;
+    const auto & value = changed_parameter.value;
+
+    if (type == ParameterType::PARAMETER_STRING) {
+      if (name == "default_bt_xml_filename") {
+        new_behavior_tree_ = true;
+        
+        std::string fullpath = current_bt_xml_filename_;
+        int beginIdx = fullpath.rfind('/');
+        std::string filename = fullpath.substr(beginIdx + 1);
+        fullpath.erase(fullpath.begin() + beginIdx + 1, fullpath.end());
+        
+        current_bt_xml_filename_ = fullpath + value.string_value;
+      }
+    }
+  }
+}
+
+
+}  // namespace nav2_bt_modes_navigator

--- a/nav2_bt_modes_navigator/src/main.cpp
+++ b/nav2_bt_modes_navigator/src/main.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+//#include "behaviortree_cpp_v3/bt_factory.h"
+
+#include "nav2_bt_modes_navigator/bt_modes_navigator.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<nav2_bt_modes_navigator::BtNavigator>();
+  rclcpp::spin(node->get_node_base_interface());
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/nav2_bt_modes_navigator/src/ros_topic_logger.cpp
+++ b/nav2_bt_modes_navigator/src/ros_topic_logger.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <utility>
+#include "nav2_bt_modes_navigator/ros_topic_logger.hpp"
+#include "tf2_ros/buffer_interface.h"
+
+namespace nav2_bt_modes_navigator
+{
+
+RosTopicLogger::RosTopicLogger(
+  const rclcpp::Node::SharedPtr & ros_node, const BT::Tree & tree)
+: StatusChangeLogger(tree.rootNode()), ros_node_(ros_node)
+{
+  log_pub_ = ros_node_->create_publisher<nav2_msgs::msg::BehaviorTreeLog>(
+    "behavior_tree_log",
+    rclcpp::QoS(10));
+}
+
+void RosTopicLogger::callback(
+  BT::Duration timestamp,
+  const BT::TreeNode & node,
+  BT::NodeStatus prev_status,
+  BT::NodeStatus status)
+{
+  nav2_msgs::msg::BehaviorTreeStatusChange event;
+
+  // BT timestamps are a duration since the epoch. Need to convert to a time_point
+  // before converting to a msg.
+#ifndef _WIN32
+  event.timestamp =
+    tf2_ros::toMsg(std::chrono::time_point<std::chrono::high_resolution_clock>(timestamp));
+#else
+  event.timestamp = tf2_ros::toMsg(timestamp);
+#endif
+  event.node_name = node.name();
+  event.previous_status = toStr(prev_status, false);
+  event.current_status = toStr(status, false);
+  event_log_.push_back(std::move(event));
+
+  RCLCPP_DEBUG(
+    ros_node_->get_logger(), "[%.3f]: %25s %s -> %s",
+    std::chrono::duration<double>(timestamp).count(),
+    node.name().c_str(),
+    toStr(prev_status, true).c_str(),
+    toStr(status, true).c_str() );
+}
+
+void RosTopicLogger::flush()
+{
+  if (event_log_.size() > 0) {
+    auto log_msg = std::make_unique<nav2_msgs::msg::BehaviorTreeLog>();
+    log_msg->timestamp = ros_node_->now();
+    log_msg->event_log = event_log_;
+    log_pub_->publish(std::move(log_msg));
+    event_log_.clear();
+  }
+}
+
+}   // namespace nav2_bt_navigator

--- a/pilot_urjc_bringup/launch/nav2_bringup_launch.py
+++ b/pilot_urjc_bringup/launch/nav2_bringup_launch.py
@@ -75,7 +75,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_share_directory('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_modes_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/pilot_urjc_bringup/launch/nav2_navigation_launch.py
+++ b/pilot_urjc_bringup/launch/nav2_navigation_launch.py
@@ -93,7 +93,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'bt_xml_file',
             default_value=os.path.join(
-                get_package_share_directory('nav2_bt_navigator'),
+                get_package_share_directory('nav2_bt_modes_navigator'),
                 'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
             description='Full path to the behavior tree xml file to use'),
 
@@ -129,8 +129,8 @@ def generate_launch_description():
             remappings=remappings),
 
         Node(
-            package='nav2_bt_navigator',
-            executable='bt_navigator',
+            package='nav2_bt_modes_navigator',
+            executable='bt_modes_navigator',
             name='bt_navigator',
             output='screen',
             parameters=[configured_params],

--- a/pilot_urjc_bringup/launch/tiago/nav2_tiago_launch.py
+++ b/pilot_urjc_bringup/launch/tiago/nav2_tiago_launch.py
@@ -90,7 +90,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_share_directory('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_modes_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/pilot_urjc_bringup/launch/turtlebot2_sim/nav2_turtlebot2_launch.py
+++ b/pilot_urjc_bringup/launch/turtlebot2_sim/nav2_turtlebot2_launch.py
@@ -85,7 +85,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_share_directory('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_modes_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/pilot_urjc_bringup/launch/turtlebot3_sim/nav2_turtlebot3_launch.py
+++ b/pilot_urjc_bringup/launch/turtlebot3_sim/nav2_turtlebot3_launch.py
@@ -82,7 +82,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_share_directory('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_modes_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/pilot_urjc_bringup/params/nav2_tb3_params.yaml
+++ b/pilot_urjc_bringup/params/nav2_tb3_params.yaml
@@ -38,6 +38,12 @@ amcl:
     z_rand: 0.5
     z_short: 0.05
     scan_topic: /mros_scan
+    set_initial_pose: True
+    initial_pose:
+      x: -2.0
+      y: -0.457
+      z: 0.0
+      yaw: 0.0
 
 amcl_map_client:
   ros__parameters:

--- a/pilot_urjc_bringup/params/pilot_modes.yaml
+++ b/pilot_urjc_bringup/params/pilot_modes.yaml
@@ -52,13 +52,13 @@ bt_navigator:
     modes:
       __DEFAULT__:
         ros__parameters:
-          bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
+          default_bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
       SIMPLE:
         ros__parameters:
-          bt_xml_filename: "navigate_w_replanning.xml"
+          default_bt_xml_filename: "navigate_w_replanning.xml"
       LOW_BATTERY:
         ros__parameters:
-          bt_xml_filename: "navigate_w_replanning_and_battery_warning.xml"
+          default_bt_xml_filename: "navigate_w_replanning_and_battery_warning.xml"
 
 pointcloud_to_laser:
   ros__parameters:
@@ -79,12 +79,12 @@ controller_server:
           FollowPath.transform_tolerance: 0.2
       SLOW:
         ros__parameters:
-          FollowPath.max_vel_x: 0.2
-          FollowPath.max_vel_theta: 0.6
+          FollowPath.max_vel_x: 0.1
+          FollowPath.max_vel_theta: 0.4
       FAST:
         ros__parameters:
-          FollowPath.max_vel_x: 0.35
-          FollowPath.max_vel_theta: 1.3
+          FollowPath.max_vel_x: 0.5
+          FollowPath.max_vel_theta: 1.5
       DEGRADED: 
         ros__parameters:
           FollowPath.max_vel_x: 0.1


### PR DESCRIPTION
This PR adds the nav2_bt_modes_navigator again to support that the system_modes changes the BT:
- I have started from the nav2_bt_navigator of the MROS-RobMoSys-ITP/navigation2 pilot-urjc branch and I have included the mechanisms to take the changes in the BT and reload it.
- I have adapted the system_modes file to the new parameter name.
- I have included this component in the launcher.