### PR TITLE
Change system modes version to master

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -17,5 +17,4 @@ repositories:
   utils/system_modes:
     type: git
     url: https://github.com/micro-ROS/system_modes
-    version: feature/rules
-
+    version: master


### PR DESCRIPTION
Hi all,

@norro asked to change the `dependencies.repos` to point to master branch at system modes repo. After the merge of this PR, I will tag it as `rose2021` as a reference for the paper accepted in this workshop.

Best

Signed-off-by: Francisco Martin Rico <fmartin@gsyc.urjc.es>